### PR TITLE
arrays.equals and nullabe TerminalNodes

### DIFF
--- a/antlr-kotlin-examples-js/build.gradle
+++ b/antlr-kotlin-examples-js/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.10'
+    ext.kotlin_version = '1.2.40'
 
     repositories {
         mavenCentral()

--- a/antlr-kotlin-examples-js/src/test/kotlin/MiniCalcParserTest.kt
+++ b/antlr-kotlin-examples-js/src/test/kotlin/MiniCalcParserTest.kt
@@ -2,10 +2,9 @@ import org.antlr.v4.kotlinruntime.ANTLRInputStream
 import org.antlr.v4.kotlinruntime.CommonTokenStream
 import org.antlr.v4.kotlinruntime.ast.Point
 import org.antlr.v4.kotlinruntime.ast.pos
-import org.antlr.v4.kotlinruntime.atn.EmptyPredictionContext
-import org.antlr.v4.kotlinruntime.atn.PredictionContext
 import org.antlr.v4.kotlinruntime.tree.TerminalNode
-import kotlin.test.*
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.Test as test
 
 class TestingParser {
@@ -66,12 +65,12 @@ class TestingParser {
         val inputDecl = statement.findInputDeclaration()!!
 
         val inputKw = inputDecl.INPUT()
-        assertEquals("input", inputKw.text)
+        assertEquals("input", inputKw?.text)
 
         val type = inputDecl.findType()!!
 
         val intKw = (type as MiniCalcParser.IntegerContext).INT()
-        assertEquals("Int", intKw.text)
+        assertEquals("Int", intKw?.text)
 
         val id = inputDecl.ID()!!
         assertEquals("width", id.text)

--- a/antlr-kotlin-examples-jvm/build.gradle
+++ b/antlr-kotlin-examples-jvm/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.10'
+    ext.kotlin_version = '1.2.40'
 
     repositories {
         mavenCentral()

--- a/antlr-kotlin-examples-jvm/build.gradle
+++ b/antlr-kotlin-examples-jvm/build.gradle
@@ -21,28 +21,26 @@ repositories {
 }
 
 dependencies {
-    compile "com.strumenta.antlr-kotlin:antlr-kotlin-runtime-common:0.0.1"
     compile "com.strumenta.antlr-kotlin:antlr-kotlin-runtime-jvm:0.0.1"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+
     testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-    //testCompile 'junit:junit:4.12'
+    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 }
 
 generateKotlinGrammarSource {
     maxHeapSize = "64m"
     arguments += ['-package', 'me.tomassetti.minicalc']
-    outputDirectory = new File("generated-src/antlr/".toString())
 }
-compileKotlin.dependsOn generateKotlinGrammarSource
+
 sourceSets {
     generated {
         kotlin.srcDir 'generated-src/antlr/'
     }
 }
-compileKotlin.source sourceSets.generated.kotlin, sourceSets.main.kotlin
-
-clean{
-    delete "generated-src"
+compileKotlin {
+    dependsOn generateKotlinGrammarSource
 }
 
 idea {

--- a/antlr-kotlin-examples-jvm/src/main/kotlin/UsingLexer.kt
+++ b/antlr-kotlin-examples-jvm/src/main/kotlin/UsingLexer.kt
@@ -1,9 +1,6 @@
-
-import org.antlr.v4.kotlinruntime.ANTLRInputStream
-import org.antlr.v4.kotlinruntime.CharStream
-import org.antlr.v4.kotlinruntime.Token
-import java.lang.RuntimeException
 import me.tomassetti.minicalc.MiniCalcLexer
+import org.antlr.v4.kotlinruntime.ANTLRInputStream
+import org.antlr.v4.kotlinruntime.Token
 
 fun main(args: Array<String>) {
 
@@ -18,7 +15,7 @@ fun main(args: Array<String>) {
 
     val input = ANTLRInputStream("1 + 2")
     val lexer = MiniCalcLexer(input)
-    var token : Token? = null
+    var token: Token? = null
     do {
         token = lexer.nextToken()
         println("TOKEN $token")

--- a/antlr-kotlin-examples-jvm/src/main/kotlin/UsingParser.kt
+++ b/antlr-kotlin-examples-jvm/src/main/kotlin/UsingParser.kt
@@ -1,10 +1,7 @@
-import org.antlr.v4.kotlinruntime.ANTLRInputStream
-import org.antlr.v4.kotlinruntime.CharStream
-import org.antlr.v4.kotlinruntime.CommonTokenStream
-import org.antlr.v4.kotlinruntime.Token
-import java.lang.RuntimeException
 import me.tomassetti.minicalc.MiniCalcLexer
 import me.tomassetti.minicalc.MiniCalcParser
+import org.antlr.v4.kotlinruntime.ANTLRInputStream
+import org.antlr.v4.kotlinruntime.CommonTokenStream
 
 fun main(args: Array<String>) {
 
@@ -22,10 +19,10 @@ fun main(args: Array<String>) {
     var parser = MiniCalcParser(CommonTokenStream(lexer))
     try {
         val root = parser.miniCalcFile()
-        println("Parsed: ${root.javaClass}")
+        println("Parsed: ${root::class}")
         println("Parsed: ${root.childCount}")
-        println("Parsed: ${root.children!![0].javaClass}")
-    } catch (e : Throwable) {
+        println("Parsed: ${root.children!![0]::class}")
+    } catch (e: Throwable) {
         println("Error: $e")
     }
 }

--- a/antlr-kotlin-examples-jvm/src/test/kotlin/MiniCalcParserTest.kt
+++ b/antlr-kotlin-examples-jvm/src/test/kotlin/MiniCalcParserTest.kt
@@ -2,17 +2,13 @@ import org.antlr.v4.kotlinruntime.ANTLRInputStream
 import org.antlr.v4.kotlinruntime.CommonTokenStream
 import org.antlr.v4.kotlinruntime.ast.Point
 import org.antlr.v4.kotlinruntime.ast.pos
-import org.antlr.v4.kotlinruntime.atn.EmptyPredictionContext
-import org.antlr.v4.kotlinruntime.atn.PredictionContext
 import org.antlr.v4.kotlinruntime.tree.TerminalNode
-import kotlin.test.*
 import kotlin.test.Test as test
-import me.tomassetti.minicalc.MiniCalcLexer
-import me.tomassetti.minicalc.MiniCalcParser
 
 class TestingParser {
 
-    @test fun simplestFileUsingHomogeneousAPI() {
+    @test
+    fun simplestFileUsingHomogeneousAPI() {
         val input = ANTLRInputStream("input Int width\n")
         val lexer = MiniCalcLexer(input)
         var parser = MiniCalcParser(CommonTokenStream(lexer))
@@ -68,12 +64,12 @@ class TestingParser {
         val inputDecl = statement.findInputDeclaration()!!
 
         val inputKw = inputDecl.INPUT()
-        assertEquals("input", inputKw.text)
+        assertEquals("input", inputKw?.text)
 
         val type = inputDecl.findType()!!
 
         val intKw = (type as MiniCalcParser.IntegerContext).INT()
-        assertEquals("Int", intKw.text)
+        assertEquals("Int", intKw?.text)
 
         val id = inputDecl.ID()!!
         assertEquals("width", id.text)

--- a/antlr-kotlin-examples-jvm/src/test/kotlin/MiniCalcParserTest.kt
+++ b/antlr-kotlin-examples-jvm/src/test/kotlin/MiniCalcParserTest.kt
@@ -1,8 +1,12 @@
+import me.tomassetti.minicalc.MiniCalcLexer
+import me.tomassetti.minicalc.MiniCalcParser
 import org.antlr.v4.kotlinruntime.ANTLRInputStream
 import org.antlr.v4.kotlinruntime.CommonTokenStream
 import org.antlr.v4.kotlinruntime.ast.Point
 import org.antlr.v4.kotlinruntime.ast.pos
 import org.antlr.v4.kotlinruntime.tree.TerminalNode
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.Test as test
 
 class TestingParser {

--- a/antlr-kotlin-gradle-plugin/build.gradle
+++ b/antlr-kotlin-gradle-plugin/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.2.40'
 
     repositories {
         mavenCentral()

--- a/antlr-kotlin-runtime-common/build.gradle
+++ b/antlr-kotlin-runtime-common/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.2.40'
 
     repositories {
         mavenCentral()

--- a/antlr-kotlin-runtime-common/src/main/kotlin/com/strumenta/kotlinmultiplatform/Misc.kt
+++ b/antlr-kotlin-runtime-common/src/main/kotlin/com/strumenta/kotlinmultiplatform/Misc.kt
@@ -27,12 +27,24 @@ expect object Arrays {
 
     fun equals(a: Array<*>, b: Array<*>): Boolean
 
+    fun equals(a: IntArray, b: IntArray): Boolean
+
     fun toString(a: Array<*>): String
 }
 
-expect class BitSet {
-    constructor()
+fun Arrays.equals(a: Array<*>?, b: Array<*>?): Boolean {
+    if (a == null && b == null) return true
+    if (a == null && b != null || a != null && b == null) return false
+    return equals(a!!, b!!)
+}
 
+fun Arrays.equals(a: IntArray?, b: IntArray?): Boolean {
+    if (a == null && b == null) return true
+    if (a == null && b != null || a != null && b == null) return false
+    return equals(a!!, b!!)
+}
+
+expect class BitSet() {
     fun set(bitIndex: Int)
     fun clear(bitIndex: Int)
     fun get(bitIndex: Int): Boolean
@@ -40,8 +52,6 @@ expect class BitSet {
     fun nextSetBit(i: Int): Int
     fun or(alts: BitSet)
 }
-
-//expect class ArrayList<T> : List<T>
 
 expect object Collections {
     fun unmodifiableList(asList: Collection<*>): List<*>

--- a/antlr-kotlin-runtime-common/src/main/kotlin/org/antlr/v4/kotlinruntime/atn/ArrayPredictionContext.kt
+++ b/antlr-kotlin-runtime-common/src/main/kotlin/org/antlr/v4/kotlinruntime/atn/ArrayPredictionContext.kt
@@ -6,6 +6,9 @@
 
 package org.antlr.v4.kotlinruntime.atn
 
+import com.strumenta.kotlinmultiplatform.Arrays
+import com.strumenta.kotlinmultiplatform.equals
+
 class ArrayPredictionContext(
         /** Parent can be null only if full ctx mode and we make an array
          * from [.EMPTY] and non-empty. We merge [.EMPTY] by using null parent and
@@ -57,9 +60,8 @@ class ArrayPredictionContext(
             return false // can't be same if hash is different
         }
 
-        val a = o as ArrayPredictionContext?
-        TODO()
-        //return Arrays.equals(returnStates, a!!.returnStates) && Arrays.equals(parents, a.parents)
+    o as ArrayPredictionContext
+    return Arrays.equals(returnStates, o.returnStates) && Arrays.equals(parents, o.parents)
     }
 //
 //    override fun toString(): String {

--- a/antlr-kotlin-runtime-js/build.gradle
+++ b/antlr-kotlin-runtime-js/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.2.40'
 
     repositories {
         mavenCentral()

--- a/antlr-kotlin-runtime-js/src/main/kotlin/com/strumenta/kotlinmultiplatform/arrays.kt
+++ b/antlr-kotlin-runtime-js/src/main/kotlin/com/strumenta/kotlinmultiplatform/arrays.kt
@@ -39,6 +39,19 @@ actual object Arrays {
         return true
     }
 
+    actual fun equals(a: IntArray, b: IntArray): Boolean {
+        if (a === b) return true
+        if (a.size != b.size) {
+            return false
+        }
+        for (i in a.indices) {
+            if (a[i] != b[i]) {
+                return false
+            }
+        }
+        return true
+    }
+
     actual fun toString(a: Array<*>): String {
         return "[${a.joinToString(separator = ", ") { it?.toString() ?: "null"}}]"
     }

--- a/antlr-kotlin-runtime-jvm/build.gradle
+++ b/antlr-kotlin-runtime-jvm/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.2.40'
 
     repositories {
         mavenCentral()

--- a/antlr-kotlin-runtime-jvm/src/main/kotlin/com/strumenta/kotlinmultiplatform/arrays.kt
+++ b/antlr-kotlin-runtime-jvm/src/main/kotlin/com/strumenta/kotlinmultiplatform/arrays.kt
@@ -28,6 +28,10 @@ actual object Arrays {
         return java.util.Arrays.equals(a, b)
     }
 
+    actual fun equals(a: IntArray, b: IntArray): Boolean {
+        return java.util.Arrays.equals(a, b)
+    }
+
     actual fun toString(a: Array<*>): String {
         return java.util.Arrays.toString(a)
     }

--- a/antlr-kotlin-target/build.gradle
+++ b/antlr-kotlin-target/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.2.40'
 
     repositories {
         mavenLocal()

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -705,11 +705,11 @@ RuleContextDecl(r) ::= "var <r.name>: <r.ctxName>? = null"
 RuleContextListDecl(rdecl) ::= "var <rdecl.name> : MutableList\<<rdecl.ctxName>> = ArrayList\<<rdecl.ctxName>>()"
 
 ContextTokenGetterDecl(t)      ::=
-    "fun <t.name>() : TerminalNode = getToken(<parser.name>.Tokens.<t.name>.id, 0) as TerminalNode"
+    "fun <t.name>() : TerminalNode? = getToken(<parser.name>.Tokens.<t.name>.id, 0)"
 ContextTokenListGetterDecl(t)  ::=
-    "fun <t.name>() : List\<TerminalNode> = getTokens(<parser.name>.Tokens.<t.name>.id) as TerminalNode"
+    "fun <t.name>() : List\<TerminalNode> = getTokens(<parser.name>.Tokens.<t.name>.id)"
 ContextTokenListIndexedGetterDecl(t)  ::= <<
-fun <t.name>(int i) : TerminalNode = getToken(<parser.name>.Tokens.<t.name>.id, i) as TerminalNode
+fun <t.name>(int i) : TerminalNode? = getToken(<parser.name>.Tokens.<t.name>.id, i)
 >>
 ContextRuleGetterDecl(r)       ::= <<
 fun find<r.name; format="cap">() : <r.ctxName>? = getRuleContext(solver.getType("<r.ctxName>"),0)


### PR DESCRIPTION
implemented Arrays.equals for nullable and primitive integer types.

TerminalNodes from ContextTokenGetter are nullable