### PR TITLE
Mainly changes to kotlin.stg to fix various issues.  Added Unit test …

### DIFF
--- a/antlr-kotlin-runtime-common/build.gradle
+++ b/antlr-kotlin-runtime-common/build.gradle
@@ -20,8 +20,11 @@ repositories {
 group = 'com.strumenta.antlr-kotlin'
 version = '0.0.1'
 
+
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test-common:$kotlin_version"
+    testCompile "junit:junit:4.12"
+    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }

--- a/antlr-kotlin-runtime-common/src/main/kotlin/org/antlr/v4/kotlinruntime/tree/ParseTreeWalker.kt
+++ b/antlr-kotlin-runtime-common/src/main/kotlin/org/antlr/v4/kotlinruntime/tree/ParseTreeWalker.kt
@@ -37,15 +37,13 @@ open class ParseTreeWalker {
     protected fun enterRule(listener: ParseTreeListener, r: RuleNode) {
         val ctx = r.ruleContext as ParserRuleContext
         listener.enterEveryRule(ctx)
-        TODO()
-        //ctx.enterRule(listener)
+        ctx.enterRule(listener)
     }
 
     protected fun exitRule(listener: ParseTreeListener, r: RuleNode) {
         val ctx = r.ruleContext as ParserRuleContext
-        TODO()
-        //ctx.exitRule(listener)
-        //listener.exitEveryRule(ctx)
+        ctx.exitRule(listener)
+        listener.exitEveryRule(ctx)
     }
 
     companion object {

--- a/antlr-kotlin-runtime-common/src/test/kotlin/LocalListener.kt
+++ b/antlr-kotlin-runtime-common/src/test/kotlin/LocalListener.kt
@@ -32,18 +32,18 @@ class LocalListener: MiniCalcParserBaseListener() {
     }
 
     private fun processPrintStatement(content: ParseTree) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        println("called processPrintStatement")
     }
 
     private fun processAssignmentStatement(content: ParseTree) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        println("called processAssignmentStatement")
     }
 
     private fun processVarDeclStatement(content: ParseTree) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        println("called processVarDeclStatement")
     }
 
     private fun processInputDeclStatement(content: ParseTree) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        println("called processInputDeclStatement")
     }
 }

--- a/antlr-kotlin-runtime-common/src/test/kotlin/LocalListener.kt
+++ b/antlr-kotlin-runtime-common/src/test/kotlin/LocalListener.kt
@@ -1,0 +1,49 @@
+import com.strumenta.minicalc.MiniCalcParser
+import com.strumenta.minicalc.MiniCalcParserBaseListener
+import org.antlr.v4.kotlinruntime.tree.ParseTree
+
+/**
+ * Copyright (c) Martin Gittins 2018.
+ * User: martingittins
+ * Date: 13/06/2018
+ * Time: 09:52
+ */
+class LocalListener: MiniCalcParserBaseListener() {
+
+    override fun exitMiniCalcFile(ctx: MiniCalcParser.MiniCalcFileContext) {
+
+        ctx.children!!.forEach { line ->
+            processLine(line)
+        }
+    }
+
+    private fun processLine(line: ParseTree) {
+        processStatement(line.getChild(0)!!)
+    }
+
+    private fun processStatement(statement: ParseTree) {
+        val content = statement.getChild(0)!!
+        when (statement) {
+            is MiniCalcParser.InputDeclarationStatementContext -> processInputDeclStatement(content)
+            is MiniCalcParser.VarDeclarationStatementContext -> processVarDeclStatement(content)
+            is MiniCalcParser.AssignmentStatementContext -> processAssignmentStatement(content)
+            is MiniCalcParser.PrintStatementContext -> processPrintStatement(content)
+        }
+    }
+
+    private fun processPrintStatement(content: ParseTree) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    private fun processAssignmentStatement(content: ParseTree) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    private fun processVarDeclStatement(content: ParseTree) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    private fun processInputDeclStatement(content: ParseTree) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}

--- a/antlr-kotlin-runtime-common/src/test/kotlin/MiniCalcParserTest.kt
+++ b/antlr-kotlin-runtime-common/src/test/kotlin/MiniCalcParserTest.kt
@@ -4,6 +4,7 @@ import org.antlr.v4.kotlinruntime.ANTLRInputStream
 import org.antlr.v4.kotlinruntime.CommonTokenStream
 import org.antlr.v4.kotlinruntime.ast.Point
 import org.antlr.v4.kotlinruntime.ast.pos
+import org.antlr.v4.kotlinruntime.tree.ParseTreeWalker
 import org.antlr.v4.kotlinruntime.tree.TerminalNode
 import kotlin.test.Test as test
 
@@ -103,6 +104,16 @@ class MiniCalcParserTest : BaseTest() {
         val parser = MiniCalcParser(CommonTokenStream(lexer))
 
         val root = parser.miniCalcFile()
+        assertEquals(pos(1, 0, 2, 0), root.position)
+    }
+
+    @test fun callListener() {
+        val input = ANTLRInputStream("input Int width\n")
+        val lexer = MiniCalcLexer(input)
+        val parser = MiniCalcParser(CommonTokenStream(lexer))
+        val root = parser.miniCalcFile()
+        val localListener = LocalListener()
+        ParseTreeWalker().walk(localListener, root)
         assertEquals(pos(1, 0, 2, 0), root.position)
     }
 }

--- a/antlr-kotlin-runtime-common/src/test/kotlin/com/strumenta/minicalc/MiniCalcParserBaseListener.kt
+++ b/antlr-kotlin-runtime-common/src/test/kotlin/com/strumenta/minicalc/MiniCalcParserBaseListener.kt
@@ -11,7 +11,7 @@ import org.antlr.v4.kotlinruntime.tree.TerminalNode
  * which can be extended to create a listener which only needs to handle a subset
  * of the available methods.
  */
-class MiniCalcParserBaseListener : MiniCalcParserListener {
+open class MiniCalcParserBaseListener : MiniCalcParserListener {
 	/**
 	 * {@inheritDoc}
 	 *

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -120,7 +120,7 @@ import org.antlr.v4.kotlinruntime.tree.TerminalNode
  * which can be extended to create a listener which only needs to handle a subset
  * of the available methods.
  */
-class <file.grammarName>BaseListener : <file.grammarName>Listener {
+open class <file.grammarName>BaseListener : <file.grammarName>Listener {
 	<file.listenerNames:{lname |
 /**
  * {@inheritDoc\}
@@ -371,7 +371,7 @@ RuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,namedActions,fina
 <altLabelCtxs:{l | <altLabelCtxs.(l)>}; separator="\n">
 
 fun <if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else><endif> <currentRule.name>(<args; separator=",">) : <currentRule.ctxType> {
-	var _localctx : <currentRule.ctxType> = <currentRule.ctxType>(context, state<currentRule.args:{a | , <a.name>}>)
+	val _localctx : <currentRule.ctxType> = <currentRule.ctxType>(context, state<currentRule.args:{a | , <a.name>}>)
 	enterRule(_localctx, <currentRule.startState>, Rules.RULE_<currentRule.name>.id)
 	<namedActions.init>
 	<locals; separator="\n">
@@ -517,7 +517,7 @@ errorHandler.sync(this)
 <if(choice.label)><labelref(choice.label)> = _input!!.LT(1)<endif>
 <preamble; separator="\n">
 when ( interpreter!!.adaptivePredict(_input!!,<choice.decision>,context) ) {
-<alts:{alt |<i> -> <alt>}; separator="\n">
+<alts:{alt |<i> -> {<alt>\}}; separator="\n">
 }
 >>
 
@@ -526,7 +526,7 @@ this.state = <choice.stateNumber>
 errorHandler.sync(this)
 when ( interpreter!!.adaptivePredict(_input!!,<choice.decision>,context) ) {
 <alts:{alt |
-<i>  <if(!choice.ast.greedy)>+1<endif>: -> <alt>}; separator="\n">
+<i>  <if(!choice.ast.greedy)>+1<endif> -> <alt>}; separator="\n">
 }
 >>
 
@@ -672,17 +672,17 @@ SetAttr(s,rhsChunks) ::= "<ctx(s)>.<s.name> = <rhsChunks>;"
 TokenLabelType() ::= "<file.TokenLabelType; null={Token}>"
 InputSymbolType() ::= "<file.InputSymbolType; null={Token}>"
 
-TokenPropertyRef_text(t) ::= "(<ctx(t)>.<t.label>!=null?<ctx(t)>.<t.label>.getText():null)"
-TokenPropertyRef_type(t) ::= "(<ctx(t)>.<t.label>!=null?<ctx(t)>.<t.label>.getType():0)"
-TokenPropertyRef_line(t) ::= "(<ctx(t)>.<t.label>!=null?<ctx(t)>.<t.label>.getLine():0)"
-TokenPropertyRef_pos(t) ::= "(<ctx(t)>.<t.label>!=null?<ctx(t)>.<t.label>.getCharPositionInLine():0)"
-TokenPropertyRef_channel(t) ::= "(<ctx(t)>.<t.label>!=null?<ctx(t)>.<t.label>.getChannel():0)"
-TokenPropertyRef_index(t) ::= "(<ctx(t)>.<t.label>!=null?<ctx(t)>.<t.label>.getTokenIndex():0)"
-TokenPropertyRef_int(t) ::= "(<ctx(t)>.<t.label>!=null?Integer.valueOf(<ctx(t)>.<t.label>.getText()):0)"
+TokenPropertyRef_text(t) ::= "(<ctx(t)>.<t.label>?.text)"
+TokenPropertyRef_type(t) ::= "(<ctx(t)>.<t.label>?.type?:0)"
+TokenPropertyRef_line(t) ::= "(<ctx(t)>.<t.label>?.line?:0)"
+TokenPropertyRef_pos(t) ::= "(<ctx(t)>.<t.label>?.charPositionInLine()?:0)"
+TokenPropertyRef_channel(t) ::= "(<ctx(t)>.<t.label>?.channel()?:0)"
+TokenPropertyRef_index(t) ::= "(<ctx(t)>.<t.label>!?.tokenIndex()?:0)"
+TokenPropertyRef_int(t) ::= "(<ctx(t)>.<t.label>?.label.asInt()?:0)"
 
-RulePropertyRef_start(r) ::= "(<ctx(r)>.<r.label>!=null?(<ctx(r)>.<r.label>.start):null)"
-RulePropertyRef_stop(r)	 ::= "(<ctx(r)>.<r.label>!=null?(<ctx(r)>.<r.label>.stop):null)"
-RulePropertyRef_text(r)	 ::= "(<ctx(r)>.<r.label>!=null?_input!!.getText(<ctx(r)>.<r.label>.start,<ctx(r)>.<r.label>.stop):null)"
+RulePropertyRef_start(r) ::= "(<ctx(r)>.<r.label>?.start)"
+RulePropertyRef_stop(r)	 ::= "(<ctx(r)>.<r.label>?.stop)"
+RulePropertyRef_text(r)	 ::= "(<ctx(r)>.<r.label>?.let { _input!!.getText(it.start, it.stop)})"
 RulePropertyRef_ctx(r)	 ::= "<ctx(r)>.<r.label>"
 RulePropertyRef_parser(r)	 ::= "this"
 
@@ -707,9 +707,9 @@ RuleContextListDecl(rdecl) ::= "var <rdecl.name> : MutableList\<<rdecl.ctxName>>
 ContextTokenGetterDecl(t)      ::=
     "fun <t.name>() : TerminalNode = getToken(<parser.name>.Tokens.<t.name>.id, 0) as TerminalNode"
 ContextTokenListGetterDecl(t)  ::=
-    "fun <t.name>() : List\<TerminalNode> = getTokens(<parser.name>.Tokens.<t.name>.id) as TerminalNode"
+    "fun <t.name>() : List\<TerminalNode> = getTokens(<parser.name>.Tokens.<t.name>.id)"
 ContextTokenListIndexedGetterDecl(t)  ::= <<
-fun <t.name>(int i) : TerminalNode = getToken(<parser.name>.Tokens.<t.name>.id, i) as TerminalNode
+fun <t.name>(i: Int) : TerminalNode = getToken(<parser.name>.Tokens.<t.name>.id, i) as TerminalNode
 >>
 ContextRuleGetterDecl(r)       ::= <<
 fun find<r.name; format="cap">() : <r.ctxName>? = getRuleContext(solver.getType("<r.ctxName>"),0)
@@ -738,16 +738,15 @@ CaptureNextTokenType(d) ::= "<d.varName> = _input!!.LA(1)"
 
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers)
 	::= <<
-open class <struct.name> : <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> : <interfaces; separator=", "><endif> {
+open class <struct.name>(parent: ParserRuleContext?, invokingState: Int) : <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>(parent, invokingState)<if(interfaces)> : <interfaces; separator=", "><endif> {
     override var ruleIndex: Int
         get() = Rules.RULE_<struct.derivedFromName>.id
         set(value) { throw RuntimeException() }
 	<attrs:{a | <a>}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
-	<if(ctorAttrs)>constructor(parent: ParserRuleContext?, invokingState: Int) : super(parent, invokingState){ ; }<endif>
-	constructor(parent: ParserRuleContext?, invokingState: Int<ctorAttrs:{a | , <a>}>) : super(parent, invokingState){
-		<struct.ctorAttrs:{a | this.<a.name> = <a.name>;}; separator="\n">
-	}
+	<if(ctorAttrs)>constructor(parent: ParserRuleContext?, invokingState: Int<ctorAttrs:{a | , <a>}>) : this(parent, invokingState){
+                   		<struct.ctorAttrs:{a | this.<a.name> = <a.name>;}; separator="\n">
+                   	}<endif>
 <if(struct.provideCopyFrom)> <! don't need copy unless we have subclasses !>
 	constructor() : super() { }
 	fun copyFrom(ctx: <struct.name>) {
@@ -782,7 +781,7 @@ fun \<T> accept(visitor : ParseTreeVisitor\<? extends T>) : T {
 }
 >>
 
-AttributeDecl(d) ::= "<d.name> : <d.type><if(d.initValue)> = <d.initValue><endif>"
+AttributeDecl(d) ::= "val <d.name> <if(d.type)>: <d.type><endif><if(d.initValue)> = <d.initValue><endif>"
 
 /** If we don't know location of label def x, use this template */
 labelref(x) ::= "<if(!x.isLocal)>(_localctx as <x.ctx.name>).<endif><x.name>"

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -738,15 +738,16 @@ CaptureNextTokenType(d) ::= "<d.varName> = _input!!.LA(1)"
 
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers)
 	::= <<
-open class <struct.name>(parent: ParserRuleContext?, invokingState: Int) : <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>(parent, invokingState)<if(interfaces)> : <interfaces; separator=", "><endif> {
+open class <struct.name> : <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> : <interfaces; separator=", "><endif> {
     override var ruleIndex: Int
         get() = Rules.RULE_<struct.derivedFromName>.id
         set(value) { throw RuntimeException() }
 	<attrs:{a | <a>}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
-	<if(ctorAttrs)>constructor(parent: ParserRuleContext?, invokingState: Int<ctorAttrs:{a | , <a>}>) : this(parent, invokingState){
-                   		<struct.ctorAttrs:{a | this.<a.name> = <a.name>;}; separator="\n">
-                   	}<endif>
+	<if(ctorAttrs)>constructor(parent: ParserRuleContext?, invokingState: Int) : super(parent, invokingState){ ; }<endif>
+	constructor(parent: ParserRuleContext?, invokingState: Int<ctorAttrs:{a | , <a>}>) : super(parent, invokingState){
+		<struct.ctorAttrs:{a | this.<a.name> = <a.name>;}; separator="\n">
+	}
 <if(struct.provideCopyFrom)> <! don't need copy unless we have subclasses !>
 	constructor() : super() { }
 	fun copyFrom(ctx: <struct.name>) {

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -371,7 +371,7 @@ RuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,namedActions,fina
 <altLabelCtxs:{l | <altLabelCtxs.(l)>}; separator="\n">
 
 fun <if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else><endif> <currentRule.name>(<args; separator=",">) : <currentRule.ctxType> {
-	val _localctx : <currentRule.ctxType> = <currentRule.ctxType>(context, state<currentRule.args:{a | , <a.name>}>)
+	var _localctx : <currentRule.ctxType> = <currentRule.ctxType>(context, state<currentRule.args:{a | , <a.name>}>)
 	enterRule(_localctx, <currentRule.startState>, Rules.RULE_<currentRule.name>.id)
 	<namedActions.init>
 	<locals; separator="\n">


### PR DESCRIPTION
…but can't get gradle to actually execute it.  Changes to kotlin.stg as follows:

  * BaseListener class needs to be 'open'.
  * Changed Rule class definitions to be more Kotlin like.  (Really to stop IDE complaining so much about it)
  * In AltBlock, (line 520) added '{}' around body of when clause, doesn't compile without this.
  * In OptionalBlock (line 529), removed incorrect ":"
  * TokenPropertyRef's ad RulePropertyRef's where still outputting Java syntax.
  * List<TerminalNode> incorrectly cast as TerminalNode (line 710)
  * 'i' sometimes declared as (int i) rather than (I: Int) (line 712)
  * Changed ParserRuleContext class definition to be more Kotlin-like (lines 741 & 747).  Not strictly necessary but improves output code.
  * Attribute declarations didn't work, made output more kotlin, but still not correct.
  * Sometimes when clause used syntax: ': ->' rather than '->'